### PR TITLE
MFC 357212.

### DIFF
--- a/lib/libfetch/fetch.c
+++ b/lib/libfetch/fetch.c
@@ -328,6 +328,8 @@ fetch_pctdecode(char *dst, const char *src, size_t dlen)
 		}
 		if (dlen-- > 0)
 			*dst++ = c;
+		else
+			return (NULL);
 	}
 	return (s);
 }
@@ -375,11 +377,15 @@ fetchParseURL(const char *URL)
 	if (p && *p == '@') {
 		/* username */
 		q = fetch_pctdecode(u->user, URL, URL_USERLEN);
+		if (q == NULL)
+			goto ouch;
 
 		/* password */
-		if (*q == ':')
+		if (*q == ':') {
 			q = fetch_pctdecode(u->pwd, q + 1, URL_PWDLEN);
-
+			if (q == NULL)
+				goto ouch;
+		}
 		p++;
 	} else {
 		p = URL;


### PR DESCRIPTION
Fix urldecode buffer overrun.

Reported by:    Duncan Overbruck
Approved by:    so
Security:       FreeBSD-SA-20:01.libfetch
Security:       CVE-2020-7450

(cherry picked from commit 1843ebca1f06e1d9655d8914ba8288572f1b4589)