### PR TITLE
MFC r343896,r343922: dhclient: Pass through exit status from script

### DIFF
--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -2350,7 +2350,8 @@ priv_script_go(void)
 	if (ip)
 		script_flush_env(ip->client);
 
-	return (wstatus & 0xff);
+	return (WIFEXITED(wstatus) ?
+	    WEXITSTATUS(wstatus) : 128 + WTERMSIG(wstatus));
 }
 
 void


### PR DESCRIPTION
The wait status is translated into 8 bits the same way as the shell
calculates $?.

(cherry picked from commit eb327bd11b28ce1442cab508695cd6af172cb815)