### PR TITLE
Do not overwrite the rule->cuid value.

### DIFF
--- a/sys/netpfil/pf/pf_ioctl.c
+++ b/sys/netpfil/pf/pf_ioctl.c
@@ -1957,7 +1957,9 @@ pf_ioctl_addrule(struct pf_krule *rule, uint32_t ticket,
 	rule->states_cur = counter_u64_alloc(M_WAITOK);
 	rule->states_tot = counter_u64_alloc(M_WAITOK);
 	rule->src_nodes = counter_u64_alloc(M_WAITOK);
+#ifdef PF_USER_INFO
 	rule->cuid = td->td_ucred->cr_ruid;
+#endif
 	rule->cpid = td->td_proc ? td->td_proc->p_pid : 0;
 	TAILQ_INIT(&rule->rpool.list);
 


### PR DESCRIPTION
pfSense uses rule->cuid to keep the userland tracker ID, hide the default
rule->cuid value under the PF_USER_INFO define.

Regression:	#11994
(cherry picked from commit 88e9b559607b33c029632748e8b863abcda7c892)