### PR TITLE
syslogd: conservative devel-main backport for RELENG_2_8_1

### DIFF
--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -2571,7 +2571,7 @@ syslogd_cap_enter(void)
 	if (cap_syslogd == NULL)
 		err(1, "Failed to open the syslogd.casper libcasper service");
 	cap_net = cap_service_open(cap_casper, "system.net");
-	if (cap_syslogd == NULL)
+	if (cap_net == NULL)
 		err(1, "Failed to open the system.net libcasper service");
 	cap_close(cap_casper);
 	limit = cap_net_limit_init(cap_net,

--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -1830,15 +1830,14 @@ fprintlog_write(struct filed *f, struct iovlist *il, int flags)
 			case EHOSTUNREACH:
 			case EHOSTDOWN:
 			case EADDRNOTAVAIL:
+			case EAGAIN:
+			case ECONNREFUSED:
 				break;
 			/* case EBADF: */
 			/* case EACCES: */
 			/* case ENOTSOCK: */
 			/* case EFAULT: */
 			/* case EMSGSIZE: */
-			/* case EAGAIN: */
-			/* case ENOBUFS: */
-			/* case ECONNREFUSED: */
 			default:
 				dprintf("removing entry: errno=%d\n", e);
 				f->f_type = F_UNUSED;

--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -810,7 +810,7 @@ main(int argc, char *argv[])
 			case SIGINT:
 			case SIGQUIT:
 			case SIGTERM:
-				if (ev.ident == SIGTERM || Debug)
+				if (ev.ident == SIGTERM || Foreground || Debug)
 					die(ev.ident);
 				break;
 			case SIGALRM:

--- a/usr.sbin/syslogd/syslogd.c
+++ b/usr.sbin/syslogd/syslogd.c
@@ -2952,8 +2952,9 @@ parse_selector(const char *p, struct filed *f)
 
 		pri = decode(buf, prioritynames);
 		if (pri < 0) {
-			dprintf("unknown priority name \"%s\"", buf);
-			return (NULL);
+			warnx("unknown priority name \"%s\", setting to 'info'",
+			    buf);
+			pri = LOG_INFO;
 		}
 	}
 	if (!pri_cmp)
@@ -2975,11 +2976,12 @@ parse_selector(const char *p, struct filed *f)
 		} else {
 			i = decode(buf, facilitynames);
 			if (i < 0) {
-				dprintf("unknown facility name \"%s\"", buf);
-				return (NULL);
+				warnx("unknown facility name \"%s\", ignoring",
+				    buf);
+			} else {
+				f->f_pmask[i >> 3] = pri;
+				f->f_pcmp[i >> 3] = pri_cmp;
 			}
-			f->f_pmask[i >> 3] = pri;
-			f->f_pcmp[i >> 3] = pri_cmp;
 		}
 		while (*p == ',' || *p == ' ')
 			p++;


### PR DESCRIPTION
### Motivation
Address the previous syslogd backport review with a smaller, conservative v2 limited strictly to `usr.sbin/syslogd/` and focused on functional/safety fixes from devel-main.

### Description
Applied functional low/medium-risk syslogd fixes:
- allow `SIGINT`/`SIGQUIT` to terminate syslogd when running in foreground (`-F`), preserving daemon-mode behavior
- check `cap_net` after opening the `system.net` Casper service
- keep forwarding targets active on transient `EAGAIN` and `ECONNREFUSED` send failures
- continue parsing configuration selectors after invalid priority/facility names, warning and using the upstream fallback behavior

Intentionally not applied:
- RFC3164 app/procid pointer arithmetic cleanup from `cddb9806b50b`, because upstream marks it as no functional change and this PR avoids cosmetic churn
- tests/manpage/Makefile changes from broader devel-main diff, because the requested safety fixes do not require them and scope is minimized

### Risk notes
- Changes are confined to `usr.sbin/syslogd/syslogd.c`.
- No rc scripts, init behavior, cron, or other subsystems are changed.
- No new API/ABI dependency was introduced; all touched symbols already exist in RELENG_2_8_1.

### Testing
Validated on FreeBSD 15 VM `10.0.0.18` using `/FreeBSD-src` on `RELENG_2_8_1` with the patch applied to temporary branch `codex-syslogd-v2-test`.

- `make -C usr.sbin/syslogd clean all`: passed
- `make -C usr.sbin/syslogd clean all WARNS=6`: passed with `-Werror`
- `make -C usr.sbin/syslogd/tests || true`: generated ATF test programs
- `kyua test` from the object tests directory: blocked by VM Kyua jail execenv setup before test case listing (`jail: ... not found`), not by a syslogd test assertion
- manual smoke tests passed:
  - valid `syslog.conf` local socket logging
  - invalid selector fallback for bad priority/facility
  - foreground `SIGINT`, `SIGQUIT`, `SIGTERM` terminate
  - foreground `SIGHUP`, `SIGALRM` keep running
  - UDP forwarding to closed localhost port does not remove target on transient errors

------
[Codex Task](https://chatgpt.com/codex/tasks)