### PR TITLE
kmod: fall back to in-tree clang intrinsic headers

### DIFF
--- a/sys/modules/aesni/Makefile
+++ b/sys/modules/aesni/Makefile
@@ -1,6 +1,10 @@
 .PATH: ${SRCTOP}/sys/crypto/aesni
 .PATH: ${SRCTOP}/contrib/llvm-project/clang/lib/Headers
 
+# Bootstrap compilers do not necessarily have their resource headers installed.
+# Keep the in-tree intrinsic headers as a fallback after the system headers.
+CFLAGS+=	-idirafter ${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+
 KMOD=	aesni
 SRCS=	aesni.c
 SRCS+=	aeskeys_${MACHINE_CPUARCH}.S

--- a/sys/modules/blake2/Makefile
+++ b/sys/modules/blake2/Makefile
@@ -3,6 +3,10 @@
 .PATH:	${SRCTOP}/sys/opencrypto
 .PATH:	${SRCTOP}/contrib/llvm-project/clang/lib/Headers
 
+# Bootstrap compilers do not necessarily have their resource headers installed.
+# Keep the in-tree intrinsic headers as a fallback after the system headers.
+CFLAGS	+= -idirafter ${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+
 KMOD	= blake2
 
 # Vendor sources


### PR DESCRIPTION
### Motivation

- Building with the `aesni` and `blake2` kernel modules failed with fatal errors like `wmmintrin.h: file not found` when using bootstrap/toolchain setups that do not expose Clang's resource headers.
- The intent is to allow these modules to compile on builders where the compiler resource-dir is not installed, while preserving normal system-header precedence.

### Description

- Add a late include fallback by appending `-idirafter ${SRCTOP}/contrib/llvm-project/clang/lib/Headers` to `CFLAGS` in `sys/modules/aesni/Makefile`.
- Apply the same `-idirafter` fallback to `sys/modules/blake2/Makefile` since it also uses x86 intrinsic headers.
- Use `-idirafter` (not `-I`) to keep system headers as the primary source and only use the in-tree Clang headers when system/compiler headers do not provide the intrinsics.
- No changes to builder scripts were required; only the two module Makefiles were modified and committed.

### Testing

- Preprocessed `wmmintrin.h` with Clang using `-nobuiltininc` and the new `-idirafter` fallback which completed successfully.
- Preprocessed `immintrin.h` with Clang using `-nobuiltininc`, `-idirafter` and appropriate defines which completed successfully.
- Ran `git diff --check` which returned no whitespace/patch issues and verified the working tree clean after commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6568cf9c44832e82cb737bad3239ad)