### PR TITLE
stand/efi/loader: set default boot policy to STRICT

### DIFF
--- a/stand/efi/loader/main.c
+++ b/stand/efi/loader/main.c
@@ -146,7 +146,7 @@ EFI_LOADED_IMAGE *boot_img;
 enum boot_policies {
 	STRICT,
 	RELAXED,
-} boot_policy = RELAXED;
+} boot_policy = STRICT;
 
 const char *policy_map[] = {
 	[STRICT] = "strict",


### PR DESCRIPTION
### Motivation
- Make the EFI loader use a stricter boot selection policy by default by changing the initial `boot_policy` value to prefer `STRICT` behavior over `RELAXED`.

### Description
- Updated the initialization in `stand/efi/loader/main.c` to set `boot_policy` from `RELAXED` to `STRICT`.

### Testing
- Performed a local build of the EFI loader (`make` for `stand/efi/loader`) and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6774b681a0832e97ff2614c4ca70e2)