### PR TITLE
release: constrain Kontrol 2.7.2 builds to amd64 without lib32

### DIFF
--- a/release/conf/Kontrol_release.conf
+++ b/release/conf/Kontrol_release.conf
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Kontrol 2.7.2 release configuration.  Invoke with:
+#     sh release/release.sh -c release/conf/Kontrol_release.conf
+#
+# This product release is deliberately amd64-only.  release.sh passes this
+# target and src.conf to its buildworld/installworld and release make jobs.
+
+TARGET="amd64"
+TARGET_ARCH="amd64"
+CHROOT_MAKEENV="TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH}"
+
+SRC_CONF="${RELENGDIR}/conf/Kontrol_src.conf"
+CHROOT_SRC_CONF="${SRC_CONF}"

--- a/release/conf/Kontrol_src.conf
+++ b/release/conf/Kontrol_src.conf
@@ -24,7 +24,12 @@ WITHOUT_HTML=YES
 WITHOUT_INETD=YES
 WITHOUT_IPFILTER=YES
 WITHOUT_JAIL=YES
-WITHOUT_LIB32=YES
+# Kontrol 2.7.2 is amd64-only.  Its 32-bit compatibility libraries are not
+# shipped; disabling them also keeps buildworld out of the build32 target.
+# Poudriere does not read this release file.  For jail Kontrol_v2_7_2_amd64,
+# create /usr/local/etc/poudriere.d/Kontrol_v2_7_2_amd64-src.conf containing:
+# WITHOUT_LIB32=yes
+WITHOUT_LIB32=yes
 WITHOUT_LOCALES=YES
 WITHOUT_LOCATE=YES
 WITHOUT_LPR=YES

--- a/release/conf/README.Kontrol-amd64
+++ b/release/conf/README.Kontrol-amd64
@@ -1,0 +1,34 @@
+Kontrol 2.7.2 amd64 build configuration
+=======================================
+
+The supported Kontrol release target is amd64/amd64.  Use the checked-in
+release driver configuration so that both the bootstrap chroot world and the
+product world consume Kontrol_src.conf:
+
+    sh release/release.sh -c release/conf/Kontrol_release.conf
+
+Kontrol does not ship amd64's optional 32-bit compatibility libraries.
+WITHOUT_LIB32=yes prevents Makefile.inc1 from adding build32 to buildworld and
+avoids requiring i386-only OpenSSL assembly such as aes-586.S.  That generated
+assembly is intentionally not added merely to hide a missing build option.
+
+Poudriere boundary
+------------------
+
+Poudriere's git jail method does not consume release/conf/Kontrol_src.conf.
+On the Poudriere host, create this exact file:
+
+    /usr/local/etc/poudriere.d/Kontrol_v2_7_2_amd64-src.conf
+
+with this exact content:
+
+    WITHOUT_LIB32=yes
+
+Then create or update the jail with architecture amd64.  Before committing to
+a long build, inspect the jail's effective make configuration:
+
+    poudriere jail -i -j Kontrol_v2_7_2_amd64
+    poudriere jail -s -j Kontrol_v2_7_2_amd64
+
+In the build log, confirm that the world is amd64/amd64, MK_LIB32 is "no", and
+there is no "stage 4.3.1: building lib32 shim libraries" or build32 target.

--- a/release/release.conf.sample
+++ b/release/release.conf.sample
@@ -35,6 +35,10 @@ PORTBRANCH="main"
 #MAKE_CONF="/etc/local/make.conf"
 #SRC_CONF="/etc/local/src.conf"
 
+## Set only when the bootstrap chroot buildworld/installworld must consume a
+## product src.conf too.  The default keeps the bootstrap world uncustomized.
+#CHROOT_SRC_CONF="/etc/local/src.conf"
+
 ## Set to use make(1) flags.
 #MAKE_FLAGS="-s"
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -87,6 +87,9 @@ env_setup() {
 	# non-default settings.
 	MAKE_CONF="/dev/null"
 	SRC_CONF="/dev/null"
+	# The bootstrap chroot normally remains an uncustomized FreeBSD world.
+	# Product release configurations may opt in to their src.conf here.
+	CHROOT_SRC_CONF="/dev/null"
 
 	# The number of make(1) jobs, defaults to the number of CPUs available
 	# for buildworld, and half of number of CPUs available for buildkernel.
@@ -159,7 +162,7 @@ env_check() {
 	# this file, unless overridden by release.conf.  In most cases, these
 	# will not need to be changed.
 	CONF_FILES="__MAKE_CONF=${MAKE_CONF} SRCCONF=${SRC_CONF}"
-	NOCONF_FILES="__MAKE_CONF=/dev/null SRCCONF=/dev/null"
+	NOCONF_FILES="__MAKE_CONF=/dev/null SRCCONF=${CHROOT_SRC_CONF}"
 	if [ -n "${TARGET}" ] && [ -n "${TARGET_ARCH}" ]; then
 		ARCH_FLAGS="TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH}"
 	else


### PR DESCRIPTION
### Motivation

- Prepare the RELENG_2_7_2 branch for Kontrol 2.7.2 as an amd64-only product so Poudriere jails and release builds do not attempt 32-bit targets or produce missing i386-only artifacts. 
- Prevent the observed build failure that surfaced when `buildworld` attempted the lib32 path which required i386 OpenSSL assembly such as `aes-586.S`. 
- Provide an auditable, minimal change that keeps upstream source for other architectures intact and documents the required Poudriere-side configuration.

### Description

- Add `release/conf/Kontrol_release.conf` which explicitly sets `TARGET="amd64"`, `TARGET_ARCH="amd64"`, and `CHROOT_MAKEENV` and points `SRC_CONF`/`CHROOT_SRC_CONF` at the product `Kontrol_src.conf` so the release driver can run an amd64-only flow. 
- Introduce an opt-in `CHROOT_SRC_CONF` in `release/release.sh` and use it for `NOCONF_FILES`/chroot make flags so a product can choose to have the bootstrap chroot consume its `src.conf` while keeping the default bootstrap behavior unchanged. 
- Normalize and document the Kontrol src knob as `WITHOUT_LIB32=yes` in `release/conf/Kontrol_src.conf`, and add `release/conf/README.Kontrol-amd64` explaining why lib32 is disabled, why `aes-586.S` is not added, and what Poudriere configuration the host must provide. 
- No architecture source code was removed, no OpenSSL sources were edited to hide errors, and no i386 assembly files were added; the fix is a configuration/driver change and documentation only.

### Testing

- Ran repository inspections and pattern searches with `rg` to confirm locations and references to `WITHOUT_LIB32`, `TARGET`, `TARGET_ARCH`, `ASM_i386` and `aes-586.S`, which succeeded and showed the OpenSSL i386 assembly is not tracked. 
- Verified `git ls-files sys/crypto/openssl/i386/aes-586.S` returned nothing, confirming the missing generated assembly. 
- Queried the build system with `bmake -m "$(pwd)/share/mk" -m "$(pwd)/tools/build/mk" -f Makefile.inc1 ... -V TARGET -V TARGET_ARCH -V MK_LIB32 -V libcompats -V WMAKE_TGTS` and observed `TARGET=amd64`, `TARGET_ARCH=amd64`, `MK_LIB32=no`, an empty `libcompats`, and `WMAKE_TGTS` without a `build32` target. 
- Performed a dry-run `bmake -n buildworld` with the Kontrol `SRCCONF` and confirmed no `build32` or `stage 4.3.1: building lib32 shim libraries` was selected, and ran `sh -n` on the new release conf to verify syntax; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68ef97b87c832ebaca83d349f06a2d)